### PR TITLE
feat: Create Git Audit Go program for commit message generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md - Instructions for AI Agents
+
+This file provides guidance for AI agents working on the `gitaudit` codebase.
+
+## Project Overview
+
+`gitaudit` is a Go command-line tool that:
+1. Takes a Git repository path and a commit ID as input.
+2. Identifies all commits between `HEAD` and the specified commit (inclusive).
+3. For each commit, generates a patch.
+4. Sends this patch to a configurable Ollama endpoint to get a detailed commit message.
+5. Writes all generated messages to `gitaudit.txt`.
+6. Configuration is stored in `~/.gitaudit` (JSON format).
+
+## Development Guidelines
+
+### Code Style
+- Follow standard Go formatting (`gofmt`).
+- Write clear, commented code, especially for complex logic (e.g., Git command interactions, API calls).
+- Ensure error handling is robust. Errors should be propagated or handled gracefully, providing informative messages to the user.
+
+### Git Usage
+- Git commands are executed via `os/exec`. Ensure these commands are constructed safely and their outputs/errors are handled correctly.
+- Pay attention to Git version differences if using newer or less common Git features, though current usage is fairly standard.
+
+### API Interaction (Ollama)
+- The Ollama API interaction involves sending a JSON request and parsing a JSON response.
+- The prompt sent to Ollama is crucial. If requirements for the generated commit message change, update the prompt string in `main.go`.
+- The `callOllama` function includes a timeout. If this needs adjustment, consider if it should be configurable.
+
+### Configuration
+- The configuration file `~/.gitaudit` is critical. Ensure that any changes to configuration options are reflected in `loadConfig` and documented in `README.md`.
+
+### Testing
+- **Manual Testing:** Before submitting changes, manually test the tool with a local Git repository.
+    - Test with a valid Ollama endpoint if possible.
+    - If a live Ollama endpoint is not available for testing, ensure the parts of the code that *don't* depend on Ollama (Git operations, file I/O, argument parsing, etc.) are functioning correctly. The current manual test in the plan (step 8) simulates this.
+    - Test edge cases:
+        - Repository not found.
+        - Invalid commit ID.
+        - Empty commit range.
+        - `~/.gitaudit` file missing or malformed.
+- **Automated Tests:** While not currently implemented, future contributions could include unit tests for specific functions (e.g., parsing, non-Git utility functions) and integration tests (potentially using a mock Git environment or a mock Ollama server).
+
+### Dependencies
+- The project uses only standard Go libraries. If adding external dependencies, use Go modules (`go get`, update `go.mod`, `go.sum`).
+
+## Workflow for Agents
+1. **Understand the Task:** Clarify any ambiguities in the request.
+2. **Plan:** Outline the steps to implement the changes. Use `set_plan`.
+3. **Implement:** Write code, following the guidelines above.
+4. **Test:** Perform manual testing as described. If you add new functionality, consider if new test cases are needed.
+5. **Document:** Update `README.md` if user-facing changes are made (e.g., new CLI options, configuration changes). Update this `AGENTS.md` if there are new considerations for future AI development.
+6. **Submit:** Use a clear commit message.
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
-# gitaudit
-A program for use in my git auditing and code review process
+# Git Audit
+
+Git Audit is a command-line tool written in Go that analyzes a range of commits in a Git repository. For each commit, it uses an AI model via a configurable Ollama endpoint to generate a new, highly detailed commit message. The final output is a single text file (`gitaudit.txt`) containing all the generated messages.
+
+## Features
+
+- Analyzes a specified range of Git commits (from `HEAD` down to a given commit ID).
+- Generates a patch for each commit.
+- Sends the patch to an Ollama endpoint to generate a detailed commit message.
+- Consolidates all AI-generated messages into a single `gitaudit.txt` file.
+- Configurable Ollama endpoint and model via `~/.gitaudit` file.
+
+## Prerequisites
+
+- Go (version 1.18 or higher recommended)
+- Git
+- An accessible Ollama instance with a downloaded model.
+
+## Installation
+
+1.  **Clone the repository (or ensure you have the source code):**
+    ```bash
+    # If you have cloned it:
+    # cd path/to/gitaudit
+    ```
+
+2.  **Build the application:**
+    ```bash
+    go build .
+    ```
+    This will create an executable named `gitaudit` in the current directory.
+
+## Configuration
+
+Before running the application, you need to create a configuration file in your home directory named `.gitaudit`. This file should be in JSON format and specify the Ollama endpoint and model.
+
+**Example `~/.gitaudit`:**
+```json
+{
+  "ollama_endpoint": "http://localhost:11434/api/generate",
+  "ollama_model": "llama2"
+}
+```
+
+- `ollama_endpoint`: The full URL to your Ollama API's generation endpoint.
+- `ollama_model`: The name of the Ollama model you wish to use (e.g., `llama2`, `mistral`, etc.). Ensure this model is available on your Ollama instance.
+
+## Usage
+
+Run the `gitaudit` executable with the following flags:
+
+```bash
+./gitaudit -repo <path_to_git_repository> -commit <oldest_commit_id>
+```
+
+- `-repo <path_to_git_repository>`: (Optional) Path to the Git repository. Defaults to the current directory (`.`).
+- `-commit <oldest_commit_id>`: (Required) The commit ID to audit down to. The program will process commits from `HEAD` to this specified commit, inclusive.
+
+**Example:**
+
+```bash
+./gitaudit -repo /path/to/my/project -commit abc1234
+```
+
+This will:
+1. Read commit history from `/path/to/my/project`.
+2. Process all commits from the current `HEAD` down to (and including) commit `abc1234`.
+3. Contact the Ollama instance defined in `~/.gitaudit`.
+4. Generate detailed commit messages.
+5. Write all generated messages to a file named `gitaudit.txt` in the directory where `gitaudit` was executed.
+6. Print a list of any commits that failed during processing.
+
+## Output
+
+- **Console:** Progress messages, errors, and a summary of processed and failed commits.
+- **`gitaudit.txt`:** A text file created in the current working directory containing all successfully AI-generated commit messages, separated by `---`. Each message corresponds to a commit in the specified range, ordered from newest (`HEAD`) to oldest.
+
+## Development
+
+To make changes to the tool:
+1. Modify the Go source files (`.go`).
+2. Rebuild the application using `go build .`.
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module gitaudit
+
+go 1.24.3

--- a/main.go
+++ b/main.go
@@ -1,0 +1,366 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// OllamaRequest defines the structure for requests to the Ollama API.
+type OllamaRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"` // Set to false for a single response
+}
+
+// OllamaResponse defines the structure for responses from the Ollama API.
+// We are interested in the "response" field for non-streaming.
+type OllamaResponse struct {
+	Model     string    `json:"model"`
+	CreatedAt time.Time `json:"created_at"`
+	Response  string    `json:"response"`
+	Done      bool      `json:"done"`
+	// Other fields might be present depending on the response, like context, total_duration, etc.
+}
+
+func main() {
+	repoPath := flag.String("repo", ".", "Path to the Git repository")
+	commitID := flag.String("commit", "", "The oldest commit ID to audit to")
+
+	flag.Parse()
+
+	if *commitID == "" {
+		fmt.Println("Error: commit ID is required.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	fmt.Printf("Repository Path: %s\n", *repoPath)
+	fmt.Printf("Commit ID: %s\n", *commitID)
+
+	config, err := loadConfig()
+	if err != nil {
+		fmt.Printf("Error loading configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Ollama Endpoint: %s\n", config.OllamaEndpoint)
+	fmt.Printf("Ollama Model: %s\n", config.OllamaModel)
+
+	commitHashes, err := getCommitHashes(*repoPath, *commitID)
+	if err != nil {
+		fmt.Printf("Error getting commit hashes: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Commit hashes to process:")
+	for _, hash := range commitHashes {
+		fmt.Println(hash)
+	}
+
+	var allGeneratedMessages []string // Slice to store all AI-generated messages
+	var failedCommits []string        // Slice to store hashes of commits that failed processing
+
+	// Generate patches for each commit
+	for _, commitHash := range commitHashes {
+		fmt.Printf("Processing commit: %s\n", commitHash)
+		patch, err := getPatchForCommit(*repoPath, commitHash)
+		if err != nil {
+			errMsg := fmt.Sprintf("Error generating patch for commit %s: %v", commitHash, err)
+			fmt.Println(errMsg)
+			failedCommits = append(failedCommits, fmt.Sprintf("%s (patch generation failed: %v)", commitHash, err))
+			continue
+		}
+		// fmt.Printf("\n--- Patch for %s ---\n", commitHash) // Optional: for debugging
+
+		// Construct the prompt for Ollama
+		prompt := fmt.Sprintf(`Given the following Git patch, please generate a highly detailed and descriptive Git commit message. The message should cover:
+1. A summary of the changes.
+2. The reasoning behind the changes (why they were made).
+3. Any problems that were encountered (if apparent from the patch or commit message).
+4. The intended purpose or goal of the commit.
+
+Do not include the "Patch:" prefix or any introductory phrases like "Here's a commit message:". Output only the commit message itself.
+
+Patch:
+%s`, patch)
+
+		// Send to Ollama
+		generatedMessage, err := callOllama(config.OllamaEndpoint, config.OllamaModel, prompt)
+		if err != nil {
+			errMsg := fmt.Sprintf("Error calling Ollama for commit %s: %v", commitHash, err)
+			fmt.Println(errMsg)
+			failedCommits = append(failedCommits, fmt.Sprintf("%s (Ollama call failed: %v)", commitHash, err))
+			continue
+		}
+		fmt.Printf("Successfully generated message for commit %s\n", commitHash)
+		allGeneratedMessages = append(allGeneratedMessages, generatedMessage)
+	}
+
+	// Write all successful messages to gitaudit.txt
+	if len(allGeneratedMessages) > 0 {
+		outputFileName := "gitaudit.txt"
+		err = writeMessagesToFile(outputFileName, allGeneratedMessages)
+		if err != nil {
+			fmt.Printf("Error writing messages to file %s: %v\n", outputFileName, err)
+			// Not exiting here, as we still want to report failed commits
+		} else {
+			fmt.Printf("\nSuccessfully wrote %d generated messages to %s\n", len(allGeneratedMessages), outputFileName)
+		}
+	} else {
+		fmt.Println("\nNo messages were successfully generated to write to file.")
+	}
+
+	if len(failedCommits) > 0 {
+		fmt.Printf("\n--- Failed Commits (%d) ---\n", len(failedCommits))
+		for _, failed := range failedCommits {
+			fmt.Println(failed)
+		}
+	}
+}
+
+// writeMessagesToFile writes a list of messages to the specified file,
+// with each message separated by a standard delimiter.
+func writeMessagesToFile(filename string, messages []string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filename, err)
+	}
+	defer file.Close()
+
+	for i, message := range messages {
+		_, err := file.WriteString(message)
+		if err != nil {
+			return fmt.Errorf("failed to write message to file: %w", err)
+		}
+		// Add a separator between messages, but not after the last one.
+		// Using a triple hyphen, similar to `git format-patch` or common document separators.
+		if i < len(messages)-1 {
+			_, err = file.WriteString("\n\n---\n\n")
+			if err != nil {
+				return fmt.Errorf("failed to write separator to file: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// callOllama sends a prompt to the Ollama API and returns the generated message.
+func callOllama(endpoint, model, promptStr string) (string, error) {
+	ollamaReq := OllamaRequest{
+		Model:  model,
+		Prompt: promptStr,
+		Stream: false, // We want a single consolidated response
+	}
+
+	reqBodyBytes, err := json.Marshal(ollamaReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Ollama request: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: 60 * time.Second} // Configurable timeout
+	httpReq, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(reqBodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP request to Ollama: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request to Ollama endpoint %s: %w", endpoint, err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		// Try to read body for more error info
+		var bodyBytes []byte
+		bodyBytes, _ = io.ReadAll(httpResp.Body) // Ignore error on read, primary error is status code
+		return "", fmt.Errorf("Ollama API request failed with status %s: %s", httpResp.Status, string(bodyBytes))
+	}
+
+	var ollamaResp OllamaResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&ollamaResp); err != nil {
+		return "", fmt.Errorf("failed to decode Ollama response: %w", err)
+	}
+
+	if !ollamaResp.Done {
+		// This might happen if stream=false is not fully respected or if there's an issue.
+		// Or, if the model sends intermediate messages even with stream=false.
+		// For a simple non-streaming request, `done` should ideally be true on the single response.
+		// However, the key is the `response` field.
+		fmt.Println("Warning: Ollama response indicates 'done' is false for a non-streaming request.")
+	}
+
+	return strings.TrimSpace(ollamaResp.Response), nil
+}
+
+// getPatchForCommit generates a patch for a given commit hash.
+// The patch includes the original commit message and the full diff.
+func getPatchForCommit(repoPath, commitHash string) (string, error) {
+	// `git show --patch <commitHash>` or `git format-patch -1 --stdout <commitHash>`
+	// `git show` is simpler as it includes the commit message and diff directly.
+	// `git format-patch` is more for creating patch files to be applied with `git am`.
+	// For sending to an LLM, `git show --patch` which includes commit metadata is good.
+	// The problem asks for "original commit message and the full set of changes (diff)".
+	// `git show --patch <commitHash>` does exactly this.
+	// `git show --patch --pretty=fuller <commitHash>` might give more detailed metadata if needed.
+	// For now, default `git show --patch` is fine.
+
+	cmd := exec.Command("git", "-C", repoPath, "show", "--patch", commitHash)
+	patchBytes, err := cmd.Output()
+	if err != nil {
+		// Attempt to get stderr for more context
+		errMsg := fmt.Sprintf("failed to execute git show for commit %s: %v", commitHash, err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			errMsg = fmt.Sprintf("%s. Stderr: %s", errMsg, string(ee.Stderr))
+		}
+		return "", fmt.Errorf(errMsg)
+	}
+	return string(patchBytes), nil
+}
+
+// getCommitHashes returns a list of commit hashes from HEAD to the specified endCommitID (inclusive)
+// in chronological order (newest to oldest).
+func getCommitHashes(repoPath, endCommitID string) ([]string, error) {
+	// git log --pretty=format:%H HEAD...endCommitID
+	// We need to include the endCommitID itself.
+	// The range HEAD..endCommitID (two dots) includes commits reachable from HEAD but not from endCommitID.
+	// The range HEAD...endCommitID (three dots) includes commits reachable from either HEAD or endCommitID but not both.
+	// Neither is quite right for "all commits between HEAD and endCommitID, inclusive".
+
+	// Let's list commits from HEAD down to the target commit.
+	// `git log --pretty=format:%H <endCommitID>^..HEAD` should work.
+	// The ^ after endCommitID makes it exclusive of endCommitID's parent, so endCommitID itself is included
+	// The order will be newest (HEAD) to oldest (endCommitID).
+
+	// Validate that repoPath is a git repository.
+	// Using `git rev-parse --is-inside-work-tree` is a more robust way to check.
+	cmdCheckRepo := exec.Command("git", "-C", repoPath, "rev-parse", "--is-inside-work-tree")
+	if err := cmdCheckRepo.Run(); err != nil {
+		// This command outputs "true" or "false" to stdout and exits 0 if it's a repo (even if not top-level).
+		// It exits non-zero if not a git repo path.
+		return nil, fmt.Errorf("path %s is not a git repository or git command failed: %w", repoPath, err)
+	}
+
+	// Ensure endCommitID is a full SHA and exists in the repo.
+	// `git rev-parse --verify <commitID>` will error if commit doesn't exist.
+	cmdResolveEndCommit := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", endCommitID)
+	resolvedEndCommitBytes, err := cmdResolveEndCommit.Output()
+	if err != nil {
+		// Error from git rev-parse includes the commit ID, so the message is informative.
+		return nil, fmt.Errorf("failed to resolve commit ID %s in repository %s: %w", endCommitID, repoPath, err)
+	}
+	resolvedEndCommitID := strings.TrimSpace(string(resolvedEndCommitBytes))
+
+	// Get all commit hashes from HEAD, newest first.
+	// `git rev-list HEAD` lists commit objects in reverse chronological order.
+	cmd := exec.Command("git", "-C", repoPath, "rev-list", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute git rev-list HEAD: %w\nOutput: %s", err, string(output))
+	}
+
+	allCommits := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var resultCommits []string
+	foundEndCommit := false
+
+	for _, commitHash := range allCommits {
+		if commitHash == "" { // Handle potential empty lines if any
+			continue
+		}
+		resultCommits = append(resultCommits, commitHash)
+		if commitHash == resolvedEndCommitID {
+			foundEndCommit = true
+			break
+		}
+	}
+
+	if !foundEndCommit {
+		return nil, fmt.Errorf("commit ID %s not found in the history of HEAD or is not an ancestor", endCommitID)
+	}
+
+	return resultCommits, nil
+}
+
+// Config holds the configuration settings for Git Audit
+type Config struct {
+	OllamaEndpoint string `json:"ollama_endpoint"`
+	OllamaModel    string `json:"ollama_model"`
+}
+
+// loadConfig reads the configuration from ~/.gitaudit
+func loadConfig() (*Config, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	configPath := fmt.Sprintf("%s/.gitaudit", homeDir)
+	configFile, err := os.Open(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("config file not found at %s. Please create it with 'ollama_endpoint' and 'ollama_model'", configPath)
+		}
+		return nil, fmt.Errorf("failed to open config file %s: %w", configPath, err)
+	}
+	defer configFile.Close()
+
+	var config Config
+	// For simplicity, we'll use a simple key=value format for now.
+	// A more robust solution would use JSON, YAML, or TOML.
+	// Example .gitaudit file:
+	// ollama_endpoint=http://localhost:11434/api/generate
+	// ollama_model=llama2
+	// This will be improved to use JSON parsing.
+
+	// Read the file line by line for now
+	// This will be replaced by proper JSON decoding.
+	// For now, let's assume fixed values for demonstration until JSON parsing is added.
+	// This is a placeholder.
+	// TODO: Implement proper JSON parsing for the config file.
+
+	// Temporary placeholder for config loading
+	// We will replace this with actual file parsing logic.
+	// For now, we'll hardcode to allow progress, then implement JSON.
+
+	// Let's create a dummy .gitaudit file for testing in the current dir
+	// and then implement the actual JSON parsing.
+
+	// This will be replaced by proper JSON decoding from ~/.gitaudit
+	// For now, this is a placeholder to allow other parts to be built.
+	// Actual implementation will use json.Decoder
+
+	// Switching to use json.Decoder as planned.
+	// Need to import "encoding/json"
+	// The config file should be in JSON format, e.g.:
+	// {
+	//   "ollama_endpoint": "http://localhost:11434/api/generate",
+	//   "ollama_model": "llama2"
+	// }
+
+	// Corrected approach: Use encoding/json
+	// Need to add `import "encoding/json"`
+	// The struct tags `json:"..."` are already in place for this.
+
+	// The file reading part is correct, now decode it.
+	// Need to add "encoding/json" to imports.
+
+	// The file opening logic is fine. Now decode.
+	decoder := json.NewDecoder(configFile)
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode config file %s: %w. Ensure it is valid JSON", configPath, err)
+	}
+
+	if config.OllamaEndpoint == "" || config.OllamaModel == "" {
+		return nil, fmt.Errorf("config file %s must contain 'ollama_endpoint' and 'ollama_model'", configPath)
+	}
+
+	return &config, nil
+}


### PR DESCRIPTION
Implements a command-line tool 'gitaudit' in Go that:
- Takes a Git repository path and a commit ID as input.
- Identifies all commits between HEAD and the specified commit (inclusive).
- Generates a patch for each commit.
- Sends the patch to a configurable Ollama endpoint (defined in ~/.gitaudit) to generate a detailed commit message based on a structured prompt.
- Writes all successfully generated messages to gitaudit.txt, ordered chronologically.
- Includes error handling for Git operations, API calls, and file I/O.
- Reports a summary of commits that failed during processing.

Also includes a README.md for usage instructions and an AGENTS.md for AI development guidelines.